### PR TITLE
addressed apple clang warnings for covering all switch cases in RcppA…

### DIFF
--- a/inst/include/RcppArrayFireWrap.h
+++ b/inst/include/RcppArrayFireWrap.h
@@ -88,6 +88,7 @@ namespace RcppArrayFire{
             case AF_STORAGE_CSR: major = "R"; break;
             case AF_STORAGE_CSC: major = "C"; break;
             case AF_STORAGE_COO: major = "T"; break;
+            case AF_STORAGE_DENSE: major = "D"; break;
         }
 
         std::string klass;
@@ -120,6 +121,10 @@ namespace RcppArrayFire{
             case AF_STORAGE_COO:
                 s.slot("i") = wrap_dense_array<int>( af::sparseGetRowIdx( object ) );
                 s.slot("j") = wrap_dense_array<int>( af::sparseGetColIdx( object ) );
+                break;
+
+            case AF_STORAGE_DENSE:
+                throw std::invalid_argument( "Not a sparse matrix" );
                 break;
         }
         s.slot("x") = wrap_dense_array<T>( af::sparseGetValues( object ) );

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // arrayfire_device_info
 Rcpp::List arrayfire_device_info();
 RcppExport SEXP _RcppArrayFire_arrayfire_device_info() {


### PR DESCRIPTION
When compiling rcpparrayfire packages on MacOS using apple clang compiler - a number of compiler warnings will surface regarding switch arguments in RcppArrayFireWrap.h file.  This adds a switch case for AF_STORAGE_DENSE that will ultimately throw an error.